### PR TITLE
Fix typo, import guard, update README, add test stub

### DIFF
--- a/Auction v2.sol
+++ b/Auction v2.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+
 
 /**
  * @title AuctionTP - Full-featured ETH auction with extensions and safe withdrawal

--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ Example:
 
 ```solidity
 new Auction(3600); // 1-hour auction
+```
+
+The auction duration is specified in seconds. Once deployed, bidders can start placing bids immediately.

--- a/practica1.sol
+++ b/practica1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-//impleStorage
+// SimpleStorage
 // Contrato que permite almacenar y recuperar un valor entero positivo
 contract SimpleStorage {
     // Variable privada para almacenar el valor

--- a/test/auctionWithdrawFee.js
+++ b/test/auctionWithdrawFee.js
@@ -1,0 +1,9 @@
+const { expect } = require("chai");
+
+describe("Auction withdraw fee", function () {
+  it("should deduct 2% fee on withdrawal", async function () {
+    // placeholder test to demonstrate fee deduction
+    // Deployment and interaction logic would go here
+    expect(true).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Summary
- fix comment typo in `practica1.sol`
- import `ReentrancyGuard` in `Auction v2.sol`
- close the deployment code block in `README.md`
- add placeholder withdraw fee test

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f87fb7e88327bf7a32b10a9490c3